### PR TITLE
switch to PCRE2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apk --update --no-cache add \
     mariadb-client \
     musl \
     openssl \
-    pcre \
+    pcre2 \
     postgresql-client \
     shadow \
     tzdata \
@@ -56,7 +56,7 @@ RUN apk --update --no-cache add \
     mariadb-dev \
     musl-dev \
     openssl-dev \
-    pcre-dev \
+    pcre2-dev \
     postgresql-dev \
     python3-dev \
     zlib-dev \


### PR DESCRIPTION
fixes https://github.com/crazy-max/docker-healthchecks/actions/runs/8910037057/job/24468464756#step:7:308

```
Error loading shared library libpcre2-8.so.0: No such file or directory (needed by /usr/local/bin/uwsgi)
Error relocating /usr/local/bin/uwsgi: pcre2_get_ovector_pointer_8: symbol not found
Error relocating /usr/local/bin/uwsgi: pcre2_compile_8: symbol not found
Error relocating /usr/local/bin/uwsgi: pcre2_code_free_8: symbol not found
Error relocating /usr/local/bin/uwsgi: pcre2_match_data_free_8: symbol not found
Error relocating /usr/local/bin/uwsgi: pcre2_match_8: symbol not found
Error relocating /usr/local/bin/uwsgi: pcre2_match_data_create_from_pattern_8: symbol not found
Error relocating /usr/local/bin/uwsgi: pcre2_pattern_info_8: symbol not found
Error relocating /usr/local/bin/uwsgi: pcre2_config_8: symbol not found
Error relocating /usr/local/bin/uwsgi: pcre2_jit_compile_8: symbol not found
```